### PR TITLE
Author email ID corrections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "authors": [
     {
       "name": "ThemeIsle Team",
-      "email": "friends@themeisle.com.com",
+      "email": "friends@themeisle.com",
       "homepage": "https://themeisle.com"
     }
   ],


### PR DESCRIPTION
Email ID was not correct in the author data.